### PR TITLE
Support parameters on path level

### DIFF
--- a/example-openapi.yaml
+++ b/example-openapi.yaml
@@ -97,6 +97,34 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /pets/{petId}/photos:
+    parameters:
+      - name: petId
+        in: path
+        required: true
+        description: The id of the pet
+        schema:
+          type: string
+    post:
+      operationId: postPetPhoto
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Photo"
+      responses:
+        200:
+          description: 200RESPONSE
+    get:
+      operationId: listPetPhotos
+      responses:
+        200:
+          description: Pet photos
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Photos"
 components:
   schemas:
     RandomThing:
@@ -189,6 +217,19 @@ components:
                 type: array
                 items:
                   type: string
+    Photo:
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+          format: int64
+        date:
+          type: string
+    Photos:
+      type: array
+      items:
+        $ref: "#/components/schemas/Photo"
     MyResponseType:
       oneOf:
         - $ref: "#/components/schemas/Cat"

--- a/spec/common.spec.ts
+++ b/spec/common.spec.ts
@@ -1,5 +1,6 @@
 import {
   capitalizeFirstLetter,
+  combineUniqueParams,
   lowercaseFirstLetter,
   normalizeOperationId,
   refToTypeName,
@@ -55,4 +56,20 @@ describe("refToTypeName", () => {
   `("refToTypeName($str) -> $expected", ({ str, expected }) => {
     expect(refToTypeName(str)).toBe(expected);
   });
+});
+
+describe("combineUniqueParams", () => {
+  it.each`
+    pathParams                      | queryParams                                                | expected
+    ${[]}                           | ${[]}                                                      | ${[]}
+    ${[]}                           | ${[{ name: "a", in: "query" }]}                            | ${[{ name: "a", in: "query" }]}
+    ${[{ name: "a", in: "path" }]}  | ${[]}                                                      | ${[{ name: "a", in: "path" }]}
+    ${[{ name: "a", in: "path" }]}  | ${[{ name: "a", in: "query" }]}                            | ${[{ name: "a", in: "query" }, { name: "a", in: "path" }]}
+    ${[{ name: "a", in: "query" }]} | ${[{ name: "a", in: "query" }, { name: "b", in: "path" }]} | ${[{ name: "a", in: "query" }, { name: "b", in: "path" }]}
+  `(
+    "combineUniqueParams($pathParams, $queryParams) -> $expected",
+    ({ pathParams, queryParams, expected }) => {
+      expect(combineUniqueParams(pathParams, queryParams)).toEqual(expected);
+    }
+  );
 });

--- a/spec/common.spec.ts
+++ b/spec/common.spec.ts
@@ -69,7 +69,9 @@ describe("combineUniqueParams", () => {
   `(
     "combineUniqueParams($pathParams, $queryParams) -> $expected",
     ({ pathParams, queryParams, expected }) => {
-      expect(combineUniqueParams(pathParams, queryParams)).toEqual(expected);
+      expect(combineUniqueParams(pathParams, queryParams)).toStrictEqual(
+        expected
+      );
     }
   );
 });

--- a/spec/mutations.spec.ts
+++ b/spec/mutations.spec.ts
@@ -4,10 +4,12 @@ import { compile } from "./test.utils";
 
 const expected = `type MutationConfigs = {
     useCreatePet?: (queryClient: QueryClient) => Pick<UseMutationOptions<Awaited<ReturnType<ReturnType<typeof makeRequests>["createPet"]>>, unknown, Parameters<ReturnType<typeof makeRequests>["createPet"]>[0], unknown>, "onSuccess" | "onSettled" | "onError">;
+    useAddPetPhoto?: (queryClient: QueryClient) => Pick<UseMutationOptions<Awaited<ReturnType<ReturnType<typeof makeRequests>["addPetPhoto"]>>, unknown, Parameters<ReturnType<typeof makeRequests>["addPetPhoto"]>[0], unknown>, "onSuccess" | "onSettled" | "onError">;
 };
 function makeMutations(requests: ReturnType<typeof makeRequests>, config?: Config["mutations"]) {
     return {
-        useCreatePet: (options?: Omit<UseMutationOptions<Awaited<ReturnType<typeof requests.createPet>>, unknown, Parameters<typeof requests.createPet>[0], unknown>, "mutationFn">) => useRapiniMutation<Awaited<ReturnType<typeof requests.createPet>>, unknown, Parameters<typeof requests.createPet>[0]>(payload => requests.createPet(payload), config?.useCreatePet, options)
+        useCreatePet: (options?: Omit<UseMutationOptions<Awaited<ReturnType<typeof requests.createPet>>, unknown, Parameters<typeof requests.createPet>[0], unknown>, "mutationFn">) => useRapiniMutation<Awaited<ReturnType<typeof requests.createPet>>, unknown, Parameters<typeof requests.createPet>[0]>(payload => requests.createPet(payload), config?.useCreatePet, options),
+        useAddPetPhoto: (petId: string, options?: Omit<UseMutationOptions<Awaited<ReturnType<typeof requests.addPetPhoto>>, unknown, Parameters<typeof requests.addPetPhoto>[0], unknown>, "mutationFn">) => useRapiniMutation<Awaited<ReturnType<typeof requests.addPetPhoto>>, unknown, Parameters<typeof requests.addPetPhoto>[0]>(payload => requests.addPetPhoto(payload, petId), config?.useAddPetPhoto, options)
     } as const;
 }
 `;
@@ -76,6 +78,58 @@ describe("makeMutations", () => {
                 },
               },
             ],
+            responses: {
+              default: {
+                description: "anything",
+                content: {
+                  "application/json": {
+                    schema: {
+                      $ref: "",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/pets/{petId}/photos": {
+          parameters: [
+            {
+              name: "petId",
+              in: "path",
+              required: true,
+              schema: {
+                type: "string",
+              },
+            },
+          ],
+          get: {
+            operationId: "getPetPhotos",
+            responses: {
+              default: {
+                description: "anything",
+                content: {
+                  "application/json": {
+                    schema: {
+                      $ref: "",
+                    },
+                  },
+                },
+              },
+            },
+          },
+          post: {
+            operationId: "addPetPhoto",
+            requestBody: {
+              description: "anything",
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "",
+                  },
+                },
+              },
+            },
             responses: {
               default: {
                 description: "anything",

--- a/spec/queries.spec.ts
+++ b/spec/queries.spec.ts
@@ -5,7 +5,8 @@ import { compile } from "./test.utils";
 const expected = `function makeQueries(requests: ReturnType<typeof makeRequests>, queryIds: ReturnType<typeof makeQueryIds>) {
     return {
         useGetPets: (options?: Omit<UseQueryOptions<Awaited<ReturnType<typeof requests.getPets>>, unknown, Awaited<ReturnType<typeof requests.getPets>>, ReturnType<(typeof queryIds)["getPets"]>>, "queryKey" | "queryFn">): UseQueryResult<Awaited<ReturnType<typeof requests.getPets>>, unknown> => useQuery(queryIds.getPets(), () => requests.getPets(), options),
-        useGetPet: (petId: string, options?: Omit<UseQueryOptions<Awaited<ReturnType<typeof requests.getPet>>, unknown, Awaited<ReturnType<typeof requests.getPet>>, ReturnType<(typeof queryIds)["getPet"]>>, "queryKey" | "queryFn">): UseQueryResult<Awaited<ReturnType<typeof requests.getPet>>, unknown> => useQuery(queryIds.getPet(petId), () => requests.getPet(petId), options)
+        useGetPet: (petId: string, options?: Omit<UseQueryOptions<Awaited<ReturnType<typeof requests.getPet>>, unknown, Awaited<ReturnType<typeof requests.getPet>>, ReturnType<(typeof queryIds)["getPet"]>>, "queryKey" | "queryFn">): UseQueryResult<Awaited<ReturnType<typeof requests.getPet>>, unknown> => useQuery(queryIds.getPet(petId), () => requests.getPet(petId), options),
+        useGetPetPhotos: (petId: string, options?: Omit<UseQueryOptions<Awaited<ReturnType<typeof requests.getPetPhotos>>, unknown, Awaited<ReturnType<typeof requests.getPetPhotos>>, ReturnType<(typeof queryIds)["getPetPhotos"]>>, "queryKey" | "queryFn">): UseQueryResult<Awaited<ReturnType<typeof requests.getPetPhotos>>, unknown> => useQuery(queryIds.getPetPhotos(petId), () => requests.getPetPhotos(petId), options)
     } as const;
 }
 `;
@@ -74,6 +75,58 @@ describe("makeQueries", () => {
                 },
               },
             ],
+            responses: {
+              default: {
+                description: "anything",
+                content: {
+                  "application/json": {
+                    schema: {
+                      $ref: "",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/pets/{petId}/photos": {
+          parameters: [
+            {
+              name: "petId",
+              in: "path",
+              required: true,
+              schema: {
+                type: "string",
+              },
+            },
+          ],
+          get: {
+            operationId: "getPetPhotos",
+            responses: {
+              default: {
+                description: "anything",
+                content: {
+                  "application/json": {
+                    schema: {
+                      $ref: "",
+                    },
+                  },
+                },
+              },
+            },
+          },
+          post: {
+            operationId: "addPetPhoto",
+            requestBody: {
+              description: "anything",
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "",
+                  },
+                },
+              },
+            },
             responses: {
               default: {
                 description: "anything",

--- a/spec/queryIds.spec.ts
+++ b/spec/queryIds.spec.ts
@@ -8,7 +8,8 @@ const expected = `function nullIfUndefined<T>(value: T): T | null {
 function makeQueryIds() {
     return {
         getPets: () => ["getPets"] as const,
-        getPet: (petId: string) => ["getPet", petId] as const
+        getPet: (petId: string) => ["getPet", petId] as const,
+        getPetPhotos: (petId: string) => ["getPetPhotos", petId] as const
     } as const;
 }
 `;
@@ -77,6 +78,58 @@ describe("makeQueryIds", () => {
                 },
               },
             ],
+            responses: {
+              default: {
+                description: "anything",
+                content: {
+                  "application/json": {
+                    schema: {
+                      $ref: "",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/pets/{petId}/photos": {
+          parameters: [
+            {
+              name: "petId",
+              in: "path",
+              required: true,
+              schema: {
+                type: "string",
+              },
+            },
+          ],
+          get: {
+            operationId: "getPetPhotos",
+            responses: {
+              default: {
+                description: "anything",
+                content: {
+                  "application/json": {
+                    schema: {
+                      $ref: "",
+                    },
+                  },
+                },
+              },
+            },
+          },
+          post: {
+            operationId: "addPetPhoto",
+            requestBody: {
+              description: "anything",
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "",
+                  },
+                },
+              },
+            },
             responses: {
               default: {
                 description: "anything",

--- a/src/common.ts
+++ b/src/common.ts
@@ -346,3 +346,20 @@ export function createParams(item: OpenAPIV3.OperationObject) {
       ),
     }));
 }
+
+// Combines path and item parameters into a single unique array.
+// A unique parameter is defined by a combination of a name and location.
+// Item parameters override path parameters with the same name and location.
+export function combineUniqueParams(
+  pathParams: (OpenAPIV3.ReferenceObject | OpenAPIV3.ParameterObject)[],
+  itemParams: (OpenAPIV3.ReferenceObject | OpenAPIV3.ParameterObject)[]
+) {
+  const paramKey = (p: OpenAPIV3.ParameterObject) => `${p.name}-${p.in}`;
+  const itemParamIds = new Set(
+    toParamObjects(itemParams).map((p) => paramKey(p))
+  );
+  return [
+    ...itemParams,
+    ...toParamObjects(pathParams).filter((p) => !itemParamIds.has(paramKey(p))),
+  ];
+}

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -95,21 +95,22 @@ function makeProperties(pattern: string, path: OpenAPIV3.PathItemObject) {
     property: ts.PropertyAssignment;
     config: ts.TypeElement;
   }[] = [];
+  const pathParams = path.parameters;
 
   if (path.post) {
-    properties.push(makeProperty(pattern, path.post, "post"));
+    properties.push(makeProperty(pattern, path.post, "post", pathParams));
   }
 
   if (path.put) {
-    properties.push(makeProperty(pattern, path.put, "put"));
+    properties.push(makeProperty(pattern, path.put, "put", pathParams));
   }
 
   if (path.patch) {
-    properties.push(makeProperty(pattern, path.patch, "patch"));
+    properties.push(makeProperty(pattern, path.patch, "patch", pathParams));
   }
 
   if (path.delete) {
-    properties.push(makeProperty(pattern, path.delete, "delete"));
+    properties.push(makeProperty(pattern, path.delete, "delete", pathParams));
   }
 
   return properties;
@@ -186,7 +187,8 @@ function optionsParameterDeclaration(
 function makeProperty(
   pattern: string,
   operation: OpenAPIV3.OperationObject,
-  method: string
+  method: string,
+  pathParams?: OpenAPIV3.PathItemObject["parameters"]
 ): { property: ts.PropertyAssignment; config: ts.TypeElement } {
   const operationId = operation.operationId;
   if (!operationId) {
@@ -195,7 +197,7 @@ function makeProperty(
   const normalizedOperationId = normalizeOperationId(operationId);
 
   const identifier = `use${capitalizeFirstLetter(normalizedOperationId)}`;
-  const params = createParams(operation);
+  const params = createParams(operation, pathParams);
 
   const hasRequestBody = !!operation.requestBody;
 

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -13,7 +13,9 @@ export function makeQueries(
 ) {
   const properties = Object.entries(paths)
     .filter(([_, item]) => !!item?.get)
-    .map(([pattern, item]) => makeProperty(pattern, item!.get));
+    .map(([pattern, item]) =>
+      makeProperty(pattern, item!.get, item!.parameters)
+    );
 
   const requestsParam = ts.factory.createParameterDeclaration(
     /*decorators*/ undefined,
@@ -77,7 +79,11 @@ export function makeQueries(
   );
 }
 
-function makeProperty(pattern: string, get: OpenAPIV3.PathItemObject["get"]) {
+function makeProperty(
+  pattern: string,
+  get: OpenAPIV3.PathItemObject["get"],
+  pathParams: OpenAPIV3.PathItemObject["parameters"]
+) {
   if (!get?.operationId) {
     throw `Missing "operationId" from "get" request with pattern ${pattern}`;
   }
@@ -85,7 +91,7 @@ function makeProperty(pattern: string, get: OpenAPIV3.PathItemObject["get"]) {
   const normalizedOperationId = normalizeOperationId(get.operationId);
   const identifierName = `use${capitalizeFirstLetter(normalizedOperationId)}`;
 
-  const params = createParams(get);
+  const params = createParams(get, pathParams);
 
   return ts.factory.createPropertyAssignment(
     /*name*/ ts.factory.createIdentifier(identifierName),

--- a/src/queryIds.ts
+++ b/src/queryIds.ts
@@ -1,10 +1,6 @@
 import ts from "typescript";
 import type { OpenAPIV3 } from "openapi-types";
-import {
-  normalizeOperationId,
-  createParams,
-  combineUniqueParams,
-} from "./common";
+import { normalizeOperationId, createParams } from "./common";
 
 const NULL_IF_UNDEFINED_FN_NAME = "nullIfUndefined";
 
@@ -120,13 +116,8 @@ function makeQueryId(
     throw `Missing "operationId" from "get" request with pattern ${pattern}`;
   }
 
-  const parameters = combineUniqueParams(
-    pathParams || [],
-    get.parameters || []
-  );
-  get.parameters = parameters;
   const normalizedOperationId = normalizeOperationId(get.operationId);
-  const params = createParams(get);
+  const params = createParams(get, pathParams);
 
   return ts.factory.createPropertyAssignment(
     /*name*/ ts.factory.createIdentifier(normalizedOperationId),

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -6,6 +6,7 @@ import {
   schemaObjectOrRefType,
   normalizeOperationId,
   isReferenceObject,
+  combineUniqueParams,
 } from "./common";
 import type { CLIOptions } from "./cli";
 
@@ -83,28 +84,41 @@ function makeRequestsPropertyAssignment(
   options: CLIOptions
 ) {
   const requests: ts.PropertyAssignment[] = [];
+  const pathParams = item.parameters;
 
   if (item.get) {
-    requests.push(makeRequest(pattern, "get", item.get, $refs, options));
+    requests.push(
+      makeRequest(pattern, "get", item.get, $refs, options, pathParams)
+    );
   }
   if (item.delete) {
-    requests.push(makeRequest(pattern, "delete", item.delete, $refs, options));
+    requests.push(
+      makeRequest(pattern, "delete", item.delete, $refs, options, pathParams)
+    );
   }
   if (item.post) {
-    requests.push(makeRequest(pattern, "post", item.post, $refs, options));
+    requests.push(
+      makeRequest(pattern, "post", item.post, $refs, options, pathParams)
+    );
   }
   if (item.put) {
-    requests.push(makeRequest(pattern, "put", item.put, $refs, options));
+    requests.push(
+      makeRequest(pattern, "put", item.put, $refs, options, pathParams)
+    );
   }
   if (item.patch) {
-    requests.push(makeRequest(pattern, "patch", item.patch, $refs, options));
+    requests.push(
+      makeRequest(pattern, "patch", item.patch, $refs, options, pathParams)
+    );
   }
   if (item.head) {
-    requests.push(makeRequest(pattern, "head", item.head, $refs, options));
+    requests.push(
+      makeRequest(pattern, "head", item.head, $refs, options, pathParams)
+    );
   }
   if (item.options) {
     requests.push(
-      makeRequest(pattern, "options", item.options, $refs, options)
+      makeRequest(pattern, "options", item.options, $refs, options, pathParams)
     );
   }
 
@@ -276,13 +290,20 @@ function makeRequest(
   method: string,
   item: OpenAPIV3.OperationObject,
   $refs: SwaggerParser.$Refs,
-  options: CLIOptions
+  options: CLIOptions,
+  pathParams?: OpenAPIV3.PathItemObject["parameters"]
 ) {
   const pathTemplateExpression = patternToPath(
     pattern,
     options.baseUrl,
     options.replacer
   );
+
+  const parameters = combineUniqueParams(
+    pathParams || [],
+    item.parameters || []
+  );
+  item.parameters = parameters;
   const arrowFuncParams = createRequestParams(item, $refs).map(
     (param) => param.arrowFuncParam
   );


### PR DESCRIPTION
This adds support for path-level parameters that can be overridden at operation level, as per [this part of the Swagger spec](https://swagger.io/specification/#:~:text=A%20list%20of%20parameters%20that%20are%20applicable%20for%20all%20the%20operations%20described%20under%20this%20path). These parameters were previously ignored, generating incomplete queries and mutations.

