### PR TITLE
Support React Query V4 aka `@tanstack/react-query`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Options:
   -o, --output-dir [directory]               Directory to output the generated package (default: "rapini-generated-package")
   -b, --base-url [url]                       Prefix every request with this url
   -r, --replacer [oldString] [newString...]  Replace part(s) of any route's path with simple string replacements. Ex: `-r /api/v1 /api/v2` would replace the v1 with v2 in every route
+  -rq-v4, --react-query-v4                   Use React Query V4 aka '@tanstack/react-query' (default: false)
   -h, --help                                 display help for command
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rapini",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rapini",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Generate React Query hooks, Axios requests and Typescript types from OpenAPI files",
   "bin": "dist/cli.js",
   "scripts": {

--- a/spec/import.spec.ts
+++ b/spec/import.spec.ts
@@ -1,13 +1,23 @@
+import { CLIOptions } from "../src/cli";
 import { makeImports } from "../src/imports";
 import { compile } from "./test.utils";
 
-const expected = `import type { AxiosInstance, AxiosRequestConfig } from "axios";
+const expectedV3 = `import type { AxiosInstance, AxiosRequestConfig } from "axios";
 import { useQuery, useMutation, useQueryClient, type QueryClient, type UseMutationOptions, type UseQueryOptions, type MutationFunction, type UseMutationResult, type UseQueryResult } from "react-query";
 `;
 
+const expectedV4 = `import type { AxiosInstance, AxiosRequestConfig } from "axios";
+import { useQuery, useMutation, useQueryClient, type QueryClient, type UseMutationOptions, type UseQueryOptions, type MutationFunction, type UseMutationResult, type UseQueryResult } from "@tanstack/react-query";
+`;
+
 describe("makeImports", () => {
-  it("generates the correct import statements", () => {
-    const str = compile(makeImports());
-    expect(str).toBe(expected);
+  it("generates the correct import statements for v3", () => {
+    const str = compile(makeImports({ reactQueryV4: false } as CLIOptions));
+    expect(str).toBe(expectedV3);
+  });
+
+  it("generates the correct import statements for v4", () => {
+    const str = compile(makeImports({ reactQueryV4: true } as CLIOptions));
+    expect(str).toBe(expectedV4);
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ export type CLIOptions = {
   path: string;
   baseUrl: string;
   replacer: string[];
+  reactQueryV4: boolean;
 };
 
 const program = new Command();
@@ -36,6 +37,11 @@ program
   .option(
     "-r, --replacer [oldString] [newString...]",
     "Replace part(s) of any route's path with simple string replacements. Ex: `-r /api/v1 /api/v2` would replace the v1 with v2 in every route"
+  )
+  .option(
+    "-rq-v4, --react-query-v4",
+    "Use React Query V4 aka '@tanstack/react-query'",
+    false
   )
   .parse();
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,7 @@ export type CLIOptions = {
 const program = new Command();
 
 program
-  .version("1.9.0")
+  .version("1.10.0")
   .description("Generate a package based on OpenAPI")
   .requiredOption("-p, --path <path>", "Path to OpenAPI file")
   .option(

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -35,6 +35,7 @@ function parseOpenApiV3Doc(
   options: CLIOptions
 ) {
   return {
+    imports: makeImports(options),
     queryIds: makeQueryIds(doc.paths),
     requests: makeRequests(doc.paths, $refs, options),
     queries: makeQueries(doc.paths, $refs),
@@ -46,7 +47,7 @@ function parseOpenApiV3Doc(
 function makeSourceFile(data: ReturnType<typeof parse>) {
   return ts.factory.createSourceFile(
     /*statements*/ [
-      ...makeImports(),
+      ...data.imports,
       ...data.types,
       ...makeConfigTypes(),
       makeInitialize(),

--- a/src/imports.ts
+++ b/src/imports.ts
@@ -1,4 +1,5 @@
 import ts from "typescript";
+import { CLIOptions } from "./cli";
 
 function makeImportAxiosInstanceTypeDeclaration() {
   return ts.factory.createImportDeclaration(
@@ -25,7 +26,7 @@ function makeImportAxiosInstanceTypeDeclaration() {
   );
 }
 
-function makeImportReactQueryDeclartion() {
+function makeImportReactQueryDeclartion(isV4: boolean) {
   const importClause = ts.factory.createImportClause(
     /*typeOnly*/ false,
     /*name*/ undefined,
@@ -82,14 +83,16 @@ function makeImportReactQueryDeclartion() {
     /*decorators*/ undefined,
     /*modifers*/ undefined,
     /*importClause*/ importClause,
-    /*moduleSpecifier*/ ts.factory.createStringLiteral("react-query"),
+    /*moduleSpecifier*/ ts.factory.createStringLiteral(
+      isV4 ? "@tanstack/react-query" : "react-query"
+    ),
     /*assertClause*/ undefined
   );
 }
 
-export function makeImports() {
+export function makeImports(options: CLIOptions) {
   return [
     makeImportAxiosInstanceTypeDeclaration(),
-    makeImportReactQueryDeclartion(),
+    makeImportReactQueryDeclartion(options.reactQueryV4),
   ];
 }

--- a/src/print.ts
+++ b/src/print.ts
@@ -20,7 +20,11 @@ function printPackageJson(options: CLIOptions) {
     },
     "peerDependencies": {
       "axios": "0.27.x",
-      "react-query": "3.x.x"
+      ${
+        options.reactQueryV4
+          ? `"@tanstack/react-query": "4.x.x"`
+          : `"react-query": "3.x.x"`
+      }
     },
     "devDependencies": {
       "@types/node": "^17.0.34",


### PR DESCRIPTION
As far as I can tell, in regards to this library, the only change to support v4 is updating the import statement to import from the new package name `@tanstack/react-query`.

There is a new CLI option to opt into v4, it still defaults to v3 to maintain backwards compatibility for existing users. If you want v4 just use the cli flag `-rq-v4` or `--react-query-v4`

this pr closes #9 