### PR TITLE
Export `makeRequests`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 This document outlines the changes from version to version.
 
+## 2.0.1
+
+- Export `makeRequests` function to support using bare Axios functions in some cases
+
 ## 2.0.0
 
 - Added support for SWR

--- a/src/common/requests.ts
+++ b/src/common/requests.ts
@@ -41,7 +41,7 @@ function makeRequestsDeclaration(
 
   return ts.factory.createFunctionDeclaration(
     /*decorators*/ undefined,
-    /*modifiers*/ undefined,
+    /*modifiers*/ [ts.factory.createToken(ts.SyntaxKind.ExportKeyword)],
     /*asteriskToken*/ undefined,
     /*name*/ ts.factory.createIdentifier("makeRequests"),
     /*typeParameters*/ undefined,


### PR DESCRIPTION
# Export `makeRequests`

this is useful in case generated function are used both by SSR and CSR. SSR is not using react query, but I still want to be able to get just the Axios functions

<!-- Please check all the boxes with [x] -->

- [x] I have added or updated unit tests for this change.
- [x] I have updated the [changelog](https://github.com/rametta/rapini/blob/main/changelog.md) with info about the changes in this PR
