### PR TITLE
🚀 feat(requests): Add support for `Content-Type` header in request

### DIFF
--- a/example-openapi.yaml
+++ b/example-openapi.yaml
@@ -110,7 +110,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          multipart/form-data:
             schema:
               $ref: "#/components/schemas/Photo"
       responses:

--- a/src/common/requests.ts
+++ b/src/common/requests.ts
@@ -10,12 +10,12 @@ import {
 import type { CLIOptions } from "../cli";
 
 export function makeRequests(
-  $refs: SwaggerParser.$Refs,
-  paths: OpenAPIV3.PathsObject,
-  options: CLIOptions
+    $refs: SwaggerParser.$Refs,
+    paths: OpenAPIV3.PathsObject,
+    options: CLIOptions
 ) {
   const requests = Object.entries(paths).flatMap(([pattern, item]) =>
-    makeRequestsPropertyAssignment($refs, pattern, item!, options)
+      makeRequestsPropertyAssignment($refs, pattern, item!, options)
   );
 
   return [
@@ -27,158 +27,157 @@ export function makeRequests(
 
 function exportRequestsType() {
   return ts.factory.createTypeAliasDeclaration(
-    undefined,
-    [ts.factory.createToken(ts.SyntaxKind.ExportKeyword)],
-    ts.factory.createIdentifier("Requests"),
-    undefined,
-    ts.factory.createTypeReferenceNode(
-      ts.factory.createIdentifier("ReturnType"),
-      [
-        ts.factory.createTypeQueryNode(
-          ts.factory.createIdentifier("makeRequests"),
-          undefined
-        ),
-      ]
-    )
+      undefined,
+      [ts.factory.createToken(ts.SyntaxKind.ExportKeyword)],
+      ts.factory.createIdentifier("Requests"),
+      undefined,
+      ts.factory.createTypeReferenceNode(
+          ts.factory.createIdentifier("ReturnType"),
+          [
+            ts.factory.createTypeQueryNode(
+                ts.factory.createIdentifier("makeRequests"),
+                undefined
+            ),
+          ]
+      )
   );
 }
 
 function exportResponseType() {
   return ts.factory.createTypeAliasDeclaration(
-    undefined,
-    [ts.factory.createToken(ts.SyntaxKind.ExportKeyword)],
-    ts.factory.createIdentifier("Response"),
-    [
-      ts.factory.createTypeParameterDeclaration(
-        undefined,
-        ts.factory.createIdentifier("T"),
-        ts.factory.createTypeOperatorNode(
-          ts.SyntaxKind.KeyOfKeyword,
-          ts.factory.createTypeReferenceNode(
-            ts.factory.createIdentifier("Requests"),
-            undefined
-          )
-        ),
-        undefined
-      ),
-    ],
-    ts.factory.createTypeReferenceNode(ts.factory.createIdentifier("Awaited"), [
-      ts.factory.createTypeReferenceNode(
-        ts.factory.createIdentifier("ReturnType"),
-        [
-          ts.factory.createIndexedAccessTypeNode(
-            ts.factory.createTypeReferenceNode(
-              ts.factory.createIdentifier("Requests"),
-              undefined
+      undefined,
+      [ts.factory.createToken(ts.SyntaxKind.ExportKeyword)],
+      ts.factory.createIdentifier("Response"),
+      [
+        ts.factory.createTypeParameterDeclaration(
+            undefined,
+            ts.factory.createIdentifier("T"),
+            ts.factory.createTypeOperatorNode(
+                ts.SyntaxKind.KeyOfKeyword,
+                ts.factory.createTypeReferenceNode(
+                    ts.factory.createIdentifier("Requests"),
+                    undefined
+                )
             ),
-            ts.factory.createTypeReferenceNode(
-              ts.factory.createIdentifier("T"),
-              undefined
-            )
-          ),
-        ]
-      ),
-    ])
+            undefined
+        ),
+      ],
+      ts.factory.createTypeReferenceNode(ts.factory.createIdentifier("Awaited"), [
+        ts.factory.createTypeReferenceNode(
+            ts.factory.createIdentifier("ReturnType"),
+            [
+              ts.factory.createIndexedAccessTypeNode(
+                  ts.factory.createTypeReferenceNode(
+                      ts.factory.createIdentifier("Requests"),
+                      undefined
+                  ),
+                  ts.factory.createTypeReferenceNode(
+                      ts.factory.createIdentifier("T"),
+                      undefined
+                  )
+              ),
+            ]
+        ),
+      ])
   );
 }
 
 function makeRequestsDeclaration(
-  requests: ReturnType<typeof makeRequestsPropertyAssignment>
+    requests: ReturnType<typeof makeRequestsPropertyAssignment>
 ) {
   const bodyStatements = [
     ts.factory.createReturnStatement(
-      /*expression*/ ts.factory.createAsExpression(
-        /*expression*/ ts.factory.createObjectLiteralExpression(
-          /*properties*/ requests,
-          /*multiline*/ true
-        ),
-        /*type*/ ts.factory.createTypeReferenceNode(
-          /*typeName*/ ts.factory.createIdentifier("const"),
-          /*typeArgs*/ undefined
+        /*expression*/ ts.factory.createAsExpression(
+            /*expression*/ ts.factory.createObjectLiteralExpression(
+                /*properties*/ requests,
+                /*multiline*/ true
+            ),
+            /*type*/ ts.factory.createTypeReferenceNode(
+                /*typeName*/ ts.factory.createIdentifier("const"),
+                /*typeArgs*/ undefined
+            )
         )
-      )
     ),
   ];
 
   return ts.factory.createFunctionDeclaration(
-    /*decorators*/ undefined,
-    /*modifiers*/ undefined,
-    /*asteriskToken*/ undefined,
-    /*name*/ ts.factory.createIdentifier("makeRequests"),
-    /*typeParameters*/ undefined,
-    /*parameters*/ [
-      ts.factory.createParameterDeclaration(
-        /*decorators*/ undefined,
-        /*modifiers*/ undefined,
-        /*dotDotDotToken*/ undefined,
-        /*name*/ ts.factory.createIdentifier("axios"),
-        /*questionToken*/ undefined,
-        /*type*/ ts.factory.createTypeReferenceNode(
-          /*typeName*/ ts.factory.createIdentifier("AxiosInstance"),
-          /*typeArguments*/ undefined
+      /*decorators*/ undefined,
+      /*modifiers*/ undefined,
+      /*asteriskToken*/ undefined,
+      /*name*/ ts.factory.createIdentifier("makeRequests"),
+      /*typeParameters*/ undefined,
+      /*parameters*/ [
+        ts.factory.createParameterDeclaration(
+            /*decorators*/ undefined,
+            /*modifiers*/ undefined,
+            /*dotDotDotToken*/ undefined,
+            /*name*/ ts.factory.createIdentifier("axios"),
+            /*questionToken*/ undefined,
+            /*type*/ ts.factory.createTypeReferenceNode(
+                /*typeName*/ ts.factory.createIdentifier("AxiosInstance"),
+                /*typeArguments*/ undefined
+            ),
+            /*initializer*/ undefined
         ),
-        /*initializer*/ undefined
-      ),
-      ts.factory.createParameterDeclaration(
-        /*decorators*/ undefined,
-        /*modifiers*/ undefined,
-        /*dotDotDotToken*/ undefined,
-        /*name*/ ts.factory.createIdentifier("config"),
-        /*questionToken*/ ts.factory.createToken(ts.SyntaxKind.QuestionToken),
-        /*type*/ ts.factory.createTypeReferenceNode(
-          /*typeName*/ ts.factory.createIdentifier("AxiosConfig"),
-          /*typeArguments*/ undefined
+        ts.factory.createParameterDeclaration(
+            /*decorators*/ undefined,
+            /*modifiers*/ undefined,
+            /*dotDotDotToken*/ undefined,
+            /*name*/ ts.factory.createIdentifier("config"),
+            /*questionToken*/ ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+            /*type*/ ts.factory.createTypeReferenceNode(
+                /*typeName*/ ts.factory.createIdentifier("AxiosConfig"),
+                /*typeArguments*/ undefined
+            ),
+            /*initializer*/ undefined
         ),
-        /*initializer*/ undefined
-      ),
-    ],
-    /*type*/ undefined,
-    /*body*/ ts.factory.createBlock(bodyStatements, /*multiline*/ true)
+      ],
+      /*type*/ undefined,
+      /*body*/ ts.factory.createBlock(bodyStatements, /*multiline*/ true)
   );
 }
 
 function makeRequestsPropertyAssignment(
-  $refs: SwaggerParser.$Refs,
-  pattern: string,
-  item: OpenAPIV3.PathItemObject,
-  options: CLIOptions
+    $refs: SwaggerParser.$Refs,
+    pattern: string,
+    item: OpenAPIV3.PathItemObject,
+    options: CLIOptions
 ) {
   const requests: ts.PropertyAssignment[] = [];
   const params = item.parameters;
-
   if (item.get) {
     requests.push(
-      makeRequest($refs, pattern, "get", item.get, options, params)
+        makeRequest($refs, pattern, "get", item.get, options, params)
     );
   }
   if (item.delete) {
     requests.push(
-      makeRequest($refs, pattern, "delete", item.delete, options, params)
+        makeRequest($refs, pattern, "delete", item.delete, options, params)
     );
   }
   if (item.post) {
     requests.push(
-      makeRequest($refs, pattern, "post", item.post, options, params)
+        makeRequest($refs, pattern, "post", item.post, options, params)
     );
   }
   if (item.put) {
     requests.push(
-      makeRequest($refs, pattern, "put", item.put, options, params)
+        makeRequest($refs, pattern, "put", item.put, options, params)
     );
   }
   if (item.patch) {
     requests.push(
-      makeRequest($refs, pattern, "patch", item.patch, options, params)
+        makeRequest($refs, pattern, "patch", item.patch, options, params)
     );
   }
   if (item.head) {
     requests.push(
-      makeRequest($refs, pattern, "head", item.head, options, params)
+        makeRequest($refs, pattern, "head", item.head, options, params)
     );
   }
   if (item.options) {
     requests.push(
-      makeRequest($refs, pattern, "options", item.options, options, params)
+        makeRequest($refs, pattern, "options", item.options, options, params)
     );
   }
 
@@ -186,32 +185,32 @@ function makeRequestsPropertyAssignment(
 }
 
 function isRequestBodyObject(
-  obj: OpenAPIV3.ReferenceObject | OpenAPIV3.RequestBodyObject
+    obj: OpenAPIV3.ReferenceObject | OpenAPIV3.RequestBodyObject
 ): obj is OpenAPIV3.RequestBodyObject {
   return "content" in obj;
 }
 
 function createRequestParams(
-  item: OpenAPIV3.OperationObject,
-  paramObjects: OpenAPIV3.ParameterObject[],
-  $refs: SwaggerParser.$Refs
+    item: OpenAPIV3.OperationObject,
+    paramObjects: OpenAPIV3.ParameterObject[],
+    $refs: SwaggerParser.$Refs
 ): { name: ts.Identifier; arrowFuncParam: ts.ParameterDeclaration }[] {
   const itemParamsDeclarations = paramObjects
-    .sort((x, y) => (x.required === y.required ? 0 : x.required ? -1 : 1)) // put all optional values at the end
-    .map((param) => ({
-      name: ts.factory.createIdentifier(param.name),
-      arrowFuncParam: ts.factory.createParameterDeclaration(
-        /*decorators*/ undefined,
-        /*modifiers*/ undefined,
-        /*dotDotDotToken*/ undefined,
-        /*name*/ ts.factory.createIdentifier(param.name),
-        /*questionToken*/ param.required
-          ? undefined
-          : ts.factory.createToken(ts.SyntaxKind.QuestionToken),
-        /*type*/ schemaObjectOrRefType($refs, param.schema).node,
-        /*initializer*/ undefined
-      ),
-    }));
+      .sort((x, y) => (x.required === y.required ? 0 : x.required ? -1 : 1)) // put all optional values at the end
+      .map((param) => ({
+        name: ts.factory.createIdentifier(param.name),
+        arrowFuncParam: ts.factory.createParameterDeclaration(
+            /*decorators*/ undefined,
+            /*modifiers*/ undefined,
+            /*dotDotDotToken*/ undefined,
+            /*name*/ ts.factory.createIdentifier(param.name),
+            /*questionToken*/ param.required
+                ? undefined
+                : ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+            /*type*/ schemaObjectOrRefType($refs, param.schema).node,
+            /*initializer*/ undefined
+        ),
+      }));
 
   if (item.requestBody) {
     const payload = ts.factory.createIdentifier("payload");
@@ -219,13 +218,13 @@ function createRequestParams(
     itemParamsDeclarations.unshift({
       name: payload,
       arrowFuncParam: ts.factory.createParameterDeclaration(
-        /*decorators*/ undefined,
-        /*modifiers*/ undefined,
-        /*dotDotDotToken*/ undefined,
-        /*name*/ payload,
-        /*questionToken*/ undefined,
-        /*type*/ makeRequestsType($refs, item.requestBody),
-        /*initializer*/ undefined
+          /*decorators*/ undefined,
+          /*modifiers*/ undefined,
+          /*dotDotDotToken*/ undefined,
+          /*name*/ payload,
+          /*questionToken*/ undefined,
+          /*type*/ makeRequestsType($refs, item.requestBody),
+          /*initializer*/ undefined
       ),
     });
   }
@@ -248,8 +247,8 @@ function statusCodeToType(statusCode: string): StatusType {
 }
 
 function mediaType(
-  $refs: SwaggerParser.$Refs,
-  mediaTypeObj: OpenAPIV3.MediaTypeObject
+    $refs: SwaggerParser.$Refs,
+    mediaTypeObj: OpenAPIV3.MediaTypeObject
 ) {
   if (!mediaTypeObj.schema) {
     return [];
@@ -261,26 +260,26 @@ function mediaType(
 }
 
 function makeAxiosRequestGenericType(
-  $refs: SwaggerParser.$Refs,
-  statusCode: string,
-  resOrRef: OpenAPIV3.ReferenceObject | OpenAPIV3.ResponseObject
+    $refs: SwaggerParser.$Refs,
+    statusCode: string,
+    resOrRef: OpenAPIV3.ReferenceObject | OpenAPIV3.ResponseObject
 ):
-  | [
-      {
-        statusType: StatusType;
-        schemas: ReturnType<typeof schemaObjectOrRefType>[];
-      }
-    ]
-  | [] {
+    | [
+  {
+    statusType: StatusType;
+    schemas: ReturnType<typeof schemaObjectOrRefType>[];
+  }
+]
+    | [] {
   const obj = isReferenceObject(resOrRef)
-    ? ($refs.get(resOrRef.$ref) as OpenAPIV3.ResponseObject)
-    : resOrRef;
+      ? ($refs.get(resOrRef.$ref) as OpenAPIV3.ResponseObject)
+      : resOrRef;
 
   const schemas = obj.content
-    ? Object.values(obj.content).flatMap((mediaTypeObj) =>
-        mediaType($refs, mediaTypeObj)
+      ? Object.values(obj.content).flatMap((mediaTypeObj) =>
+          mediaType($refs, mediaTypeObj)
       )
-    : [];
+      : [];
 
   if (!schemas.length) {
     return [];
@@ -295,33 +294,33 @@ function makeAxiosRequestGenericType(
 }
 
 export function getAxiosRequestGenericTypeResponse(
-  item: OpenAPIV3.OperationObject,
-  $refs: SwaggerParser.$Refs
+    item: OpenAPIV3.OperationObject,
+    $refs: SwaggerParser.$Refs
 ) {
   const genericType = Object.entries(item.responses).flatMap(
-    ([statusCode, resOrRef]) =>
-      makeAxiosRequestGenericType($refs, statusCode, resOrRef)
+      ([statusCode, resOrRef]) =>
+          makeAxiosRequestGenericType($refs, statusCode, resOrRef)
   );
 
   const successTypes = genericType
-    .filter(({ statusType }) => statusType === "success")
-    .flatMap(({ schemas }) => schemas);
+      .filter(({ statusType }) => statusType === "success")
+      .flatMap(({ schemas }) => schemas);
 
   const uniqSuccessTypes = successTypes.reduce<
-    ReturnType<typeof schemaObjectOrRefType>[]
+      ReturnType<typeof schemaObjectOrRefType>[]
   >(
-    (acc, node) => (acc.find((n) => n.id === node.id) ? acc : acc.concat(node)),
-    []
+      (acc, node) => (acc.find((n) => n.id === node.id) ? acc : acc.concat(node)),
+      []
   );
 
   if (uniqSuccessTypes.length) {
     return ts.factory.createUnionTypeNode(
-      uniqSuccessTypes.map((item) => item.node)
+        uniqSuccessTypes.map((item) => item.node)
     );
   }
 
   const defaultType = genericType.find(
-    ({ statusType }) => statusType === "default"
+      ({ statusType }) => statusType === "default"
   );
 
   if (defaultType && defaultType.schemas?.[0]) {
@@ -332,26 +331,26 @@ export function getAxiosRequestGenericTypeResponse(
 }
 
 function makeRequestsType(
-  $refs: SwaggerParser.$Refs,
-  reqOrRef: OpenAPIV3.ReferenceObject | OpenAPIV3.RequestBodyObject
+    $refs: SwaggerParser.$Refs,
+    reqOrRef: OpenAPIV3.ReferenceObject | OpenAPIV3.RequestBodyObject
 ) {
   const reqBody = isRequestBodyObject(reqOrRef)
-    ? reqOrRef
-    : ($refs.get(reqOrRef.$ref) as OpenAPIV3.RequestBodyObject);
+      ? reqOrRef
+      : ($refs.get(reqOrRef.$ref) as OpenAPIV3.RequestBodyObject);
 
   const schemas = reqBody.content
-    ? Object.values(reqBody.content).flatMap((mediaTypeObj) =>
-        mediaType($refs, mediaTypeObj)
+      ? Object.values(reqBody.content).flatMap((mediaTypeObj) =>
+          mediaType($refs, mediaTypeObj)
       )
-    : undefined;
+      : undefined;
 
   if (schemas?.length) {
     const uniqSchema = schemas.reduce<
-      ReturnType<typeof schemaObjectOrRefType>[]
+        ReturnType<typeof schemaObjectOrRefType>[]
     >(
-      (acc, node) =>
-        acc.find((n) => n.id === node.id) ? acc : acc.concat(node),
-      []
+        (acc, node) =>
+            acc.find((n) => n.id === node.id) ? acc : acc.concat(node),
+        []
     );
 
     return ts.factory.createUnionTypeNode(uniqSchema.map((item) => item.node));
@@ -361,137 +360,155 @@ function makeRequestsType(
 }
 
 function makeRequest(
-  $refs: SwaggerParser.$Refs,
-  pattern: string,
-  method: string,
-  item: OpenAPIV3.OperationObject,
-  options: CLIOptions,
-  pathParams?: OpenAPIV3.PathItemObject["parameters"]
+    $refs: SwaggerParser.$Refs,
+    pattern: string,
+    method: string,
+    item: OpenAPIV3.OperationObject,
+    options: CLIOptions,
+    pathParams?: OpenAPIV3.PathItemObject["parameters"]
 ) {
   const pathTemplateExpression = patternToPath(
-    pattern,
-    options.baseUrl,
-    options.replacer
+      pattern,
+      options.baseUrl,
+      options.replacer
   );
 
   const paramObjects = combineUniqueParams($refs, pathParams, item.parameters);
   const arrowFuncParams = createRequestParams(item, paramObjects, $refs).map(
-    (param) => param.arrowFuncParam
+      (param) => param.arrowFuncParam
   );
 
   const axiosRequestGenericType = getAxiosRequestGenericTypeResponse(
-    item,
-    $refs
+      item,
+      $refs
   );
 
   const axiosConfigFields = [
     ts.factory.createPropertyAssignment(
-      /*name*/ ts.factory.createIdentifier("method"),
-      /*initializer*/ ts.factory.createStringLiteral(method)
+        /*name*/ ts.factory.createIdentifier("method"),
+        /*initializer*/ ts.factory.createStringLiteral(method)
     ),
     ts.factory.createPropertyAssignment(
-      /*name*/ ts.factory.createIdentifier("url"),
-      /*initializer*/ pathTemplateExpression
-    ),
+        /*name*/ ts.factory.createIdentifier("url"),
+        /*initializer*/ pathTemplateExpression
+    )
   ];
 
   const queryParamObjects = paramObjects.filter(
-    (paramObject) => paramObject.in === "query"
+      (paramObject) => paramObject.in === "query"
   );
   const queryParamProperties = queryParamObjects.map((paramObject) =>
-    paramObject.required
-      ? ts.factory.createShorthandPropertyAssignment(
-          /*name*/ ts.factory.createIdentifier(paramObject.name),
-          /*objectAssignmentInitializer*/ undefined
-        )
-      : shorthandOptionalObjectLiteralSpread(paramObject.name)
+      paramObject.required
+          ? ts.factory.createShorthandPropertyAssignment(
+              /*name*/ ts.factory.createIdentifier(paramObject.name),
+              /*objectAssignmentInitializer*/ undefined
+          )
+          : shorthandOptionalObjectLiteralSpread(paramObject.name)
   );
 
   if (queryParamProperties.length) {
     axiosConfigFields.push(
-      ts.factory.createPropertyAssignment(
-        /*name*/ ts.factory.createIdentifier("params"),
-        /*initializer*/ ts.factory.createObjectLiteralExpression(
-          /*properties*/ queryParamProperties,
-          /*multiline*/ true
+        ts.factory.createPropertyAssignment(
+            /*name*/ ts.factory.createIdentifier("params"),
+            /*initializer*/ ts.factory.createObjectLiteralExpression(
+                /*properties*/ queryParamProperties,
+                /*multiline*/ true
+            )
+        ),
+        ts.factory.createPropertyAssignment(
+            /*name*/ ts.factory.createIdentifier("paramsSerializer"),
+            /*initializer*/ ts.factory.createPropertyAccessChain(
+                /*expression*/ ts.factory.createIdentifier("config"),
+                /*questionDotToken*/ ts.factory.createToken(
+                    ts.SyntaxKind.QuestionDotToken
+                ),
+                /*name*/ ts.factory.createIdentifier("paramsSerializer")
+            )
         )
-      ),
-      ts.factory.createPropertyAssignment(
-        /*name*/ ts.factory.createIdentifier("paramsSerializer"),
-        /*initializer*/ ts.factory.createPropertyAccessChain(
-          /*expression*/ ts.factory.createIdentifier("config"),
-          /*questionDotToken*/ ts.factory.createToken(
-            ts.SyntaxKind.QuestionDotToken
-          ),
-          /*name*/ ts.factory.createIdentifier("paramsSerializer")
-        )
-      )
     );
   }
 
   // `data` field is only allowed for certain methods
   if (item.requestBody && ["put", "post", "patch", "delete"].includes(method)) {
+
     axiosConfigFields.push(
-      ts.factory.createPropertyAssignment(
-        /*name*/ ts.factory.createIdentifier("data"),
-        /*initializer*/ ts.factory.createIdentifier("payload")
-      )
+        ts.factory.createPropertyAssignment(
+            /*name*/ ts.factory.createIdentifier("data"),
+            /*initializer*/ ts.factory.createIdentifier("payload")
+        )
     );
+    // Can be used in response type too
+    if ("content" in item.requestBody) {
+      axiosConfigFields.push(
+          ts.factory.createPropertyAssignment(
+              /*name*/ ts.factory.createIdentifier("headers"),
+              /*initializer*/ ts.factory.createObjectLiteralExpression(
+                  /*properties*/ [
+                    ts.factory.createPropertyAssignment(
+                        /*name*/ ts.factory.createStringLiteral(`Content-Type`),
+                        /*initializer*/ ts.factory.createStringLiteral(Object.keys(item.requestBody.content).at(0) ?? "application/json")
+                    ),
+                  ],
+                  /*multiline*/ true
+              )
+          ),
+      )
+    }
   }
 
   return ts.factory.createPropertyAssignment(
-    ts.factory.createIdentifier(normalizeOperationId(item.operationId!)),
-    ts.factory.createArrowFunction(
-      /*modifiers*/ undefined,
-      /*typeParams*/ undefined,
-      /*params*/ arrowFuncParams,
-      /*type*/ undefined,
-      /*equalsGreaterThanToken*/ ts.factory.createToken(
-        ts.SyntaxKind.EqualsGreaterThanToken
-      ),
-      /*body*/
-      ts.factory.createCallExpression(
-        /*expression*/ ts.factory.createPropertyAccessExpression(
-          /*expression*/ ts.factory.createCallExpression(
-            /*expression*/ ts.factory.createPropertyAccessExpression(
-              /*expression*/ ts.factory.createIdentifier("axios"),
-              /*name*/ ts.factory.createIdentifier("request")
-            ),
-            /*typeArgs*/ [axiosRequestGenericType],
-            /*args*/ [
-              ts.factory.createObjectLiteralExpression(axiosConfigFields, true),
-            ]
-          ),
-          /*name*/ ts.factory.createIdentifier("then")
-        ),
-        /*typeArgs*/ undefined,
-        /*args*/ [
-          ts.factory.createArrowFunction(
-            /*modifiers*/ undefined,
-            /*typeParameters*/ undefined,
-            /*parameters*/ [
-              ts.factory.createParameterDeclaration(
-                /*decorators*/ undefined,
-                /*modifiers*/ undefined,
-                /*dotDotDotToken*/ undefined,
-                /*name*/ ts.factory.createIdentifier("res"),
-                /*questionToken*/ undefined,
-                /*type*/ undefined,
-                /*initializer*/ undefined
-              ),
-            ],
-            /*type*/ undefined,
-            /*equalsGreaterThanToken*/ ts.factory.createToken(
+      ts.factory.createIdentifier(normalizeOperationId(item.operationId!)),
+      ts.factory.createArrowFunction(
+          /*modifiers*/ undefined,
+          /*typeParams*/ undefined,
+          /*params*/ arrowFuncParams,
+          /*type*/ undefined,
+          /*equalsGreaterThanToken*/ ts.factory.createToken(
               ts.SyntaxKind.EqualsGreaterThanToken
-            ),
-            /*body*/ ts.factory.createPropertyAccessExpression(
-              /*expression*/ ts.factory.createIdentifier("res"),
-              /*name*/ ts.factory.createIdentifier("data")
-            )
           ),
-        ]
+          /*body*/
+          ts.factory.createCallExpression(
+              /*expression*/ ts.factory.createPropertyAccessExpression(
+                  /*expression*/ ts.factory.createCallExpression(
+                      /*expression*/ ts.factory.createPropertyAccessExpression(
+                          /*expression*/ ts.factory.createIdentifier("axios"),
+                          /*name*/ ts.factory.createIdentifier("request")
+                      ),
+                      /*typeArgs*/ [axiosRequestGenericType],
+                      /*args*/ [
+                        ts.factory.createObjectLiteralExpression(axiosConfigFields, true),
+                      ]
+                  ),
+                  /*name*/ ts.factory.createIdentifier("then")
+              ),
+              /*typeArgs*/ undefined,
+              /*args*/ [
+                ts.factory.createArrowFunction(
+                    /*modifiers*/ undefined,
+                    /*typeParameters*/ undefined,
+                    /*parameters*/ [
+                      ts.factory.createParameterDeclaration(
+                          /*decorators*/ undefined,
+                          /*modifiers*/ undefined,
+                          /*dotDotDotToken*/ undefined,
+                          /*name*/ ts.factory.createIdentifier("res"),
+                          /*questionToken*/ undefined,
+                          /*type*/ undefined,
+                          /*initializer*/ undefined
+                      ),
+                    ],
+                    /*type*/ undefined,
+                    /*equalsGreaterThanToken*/ ts.factory.createToken(
+                        ts.SyntaxKind.EqualsGreaterThanToken
+                    ),
+                    /*body*/ ts.factory.createPropertyAccessExpression(
+                        /*expression*/ ts.factory.createIdentifier("res"),
+                        /*name*/ ts.factory.createIdentifier("data")
+                    )
+                ),
+              ]
+          )
       )
-    )
   );
 }
 
@@ -499,29 +516,29 @@ function makeRequest(
 // Ex: ...(identifier !== undefined ? { identifier } : undefined)
 function shorthandOptionalObjectLiteralSpread(identifier: string) {
   return ts.factory.createSpreadAssignment(
-    ts.factory.createParenthesizedExpression(
-      ts.factory.createConditionalExpression(
-        /*condition*/ ts.factory.createBinaryExpression(
-          /*left*/ ts.factory.createIdentifier(identifier),
-          /*operator*/ ts.factory.createToken(
-            ts.SyntaxKind.ExclamationEqualsEqualsToken
-          ),
-          /*right*/ ts.factory.createIdentifier("undefined")
-        ),
-        /*questionToken*/ ts.factory.createToken(ts.SyntaxKind.QuestionToken),
-        /*whenTrue*/ ts.factory.createObjectLiteralExpression(
-          /*properties*/ [
-            ts.factory.createShorthandPropertyAssignment(
-              /*name*/ ts.factory.createIdentifier(identifier),
-              /*objectAssignmentInitializer*/ undefined
-            ),
-          ],
-          /*multiLine*/ false
-        ),
-        /*colonToken*/ ts.factory.createToken(ts.SyntaxKind.ColonToken),
-        /*whenFalse*/ ts.factory.createIdentifier("undefined")
+      ts.factory.createParenthesizedExpression(
+          ts.factory.createConditionalExpression(
+              /*condition*/ ts.factory.createBinaryExpression(
+                  /*left*/ ts.factory.createIdentifier(identifier),
+                  /*operator*/ ts.factory.createToken(
+                      ts.SyntaxKind.ExclamationEqualsEqualsToken
+                  ),
+                  /*right*/ ts.factory.createIdentifier("undefined")
+              ),
+              /*questionToken*/ ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+              /*whenTrue*/ ts.factory.createObjectLiteralExpression(
+                  /*properties*/ [
+                    ts.factory.createShorthandPropertyAssignment(
+                        /*name*/ ts.factory.createIdentifier(identifier),
+                        /*objectAssignmentInitializer*/ undefined
+                    ),
+                  ],
+                  /*multiLine*/ false
+              ),
+              /*colonToken*/ ts.factory.createToken(ts.SyntaxKind.ColonToken),
+              /*whenFalse*/ ts.factory.createIdentifier("undefined")
+          )
       )
-    )
   );
 }
 
@@ -533,38 +550,38 @@ const patternRegex = /({.+?})/;
 const bracesRegex = /{|}/g;
 
 export function patternToPath(
-  pattern: string,
-  baseUrl: string,
-  replacers: string[]
+    pattern: string,
+    baseUrl: string,
+    replacers: string[]
 ) {
   const replacedPattern = replacers?.length
-    ? replacePattern(pattern, replacers)
-    : pattern;
+      ? replacePattern(pattern, replacers)
+      : pattern;
   const splits = replacedPattern.split(patternRegex);
   const [head, ...tail] = splits;
 
   const headWithBase = baseUrl ? baseUrl + head : head;
   if (tail.length === 0) {
     return ts.factory.createNoSubstitutionTemplateLiteral(
-      /*text*/ headWithBase,
-      /*rawText*/ headWithBase
+        /*text*/ headWithBase,
+        /*rawText*/ headWithBase
     );
   }
 
   const headTemplate = ts.factory.createTemplateHead(
-    /*text*/ headWithBase,
-    /*rawText*/ headWithBase
+      /*text*/ headWithBase,
+      /*rawText*/ headWithBase
   );
 
   const chunks: string[][] = chunker(tail, 2);
 
   const middleTemplates = chunks.map(([name, path], index) =>
-    ts.factory.createTemplateSpan(
-      /*expression*/ ts.factory.createIdentifier(name.replace(bracesRegex, "")),
-      /*literal*/ index === chunks.length - 1
-        ? ts.factory.createTemplateTail(path, path)
-        : ts.factory.createTemplateMiddle(path, path)
-    )
+      ts.factory.createTemplateSpan(
+          /*expression*/ ts.factory.createIdentifier(name.replace(bracesRegex, "")),
+          /*literal*/ index === chunks.length - 1
+              ? ts.factory.createTemplateTail(path, path)
+              : ts.factory.createTemplateMiddle(path, path)
+      )
   );
 
   return ts.factory.createTemplateExpression(headTemplate, middleTemplates);
@@ -584,7 +601,7 @@ export function chunker<T>(arr: T[], chunkSize: number): T[][] {
 export function replacePattern(pattern: string, replacers: string[]) {
   const chunks = chunker(replacers, 2);
   return chunks.reduce(
-    (acc, [oldStr, newStr]) => acc.replace(new RegExp(oldStr, "g"), newStr),
-    pattern
+      (acc, [oldStr, newStr]) => acc.replace(new RegExp(oldStr, "g"), newStr),
+      pattern
   );
 }


### PR DESCRIPTION
- Update `requests.ts` to include `Content-Type` header in the Axios configuration object for requests that have a request body.
- The `Content-Type` header is set based on the available content types specified in the request body.
- Also, include the `Content-Type` header in the response type if it is present in the request body.

src/common/requests.ts starting form line 441:
- Add logic to include the `Content-Type` header in the Axios configuration fields for requests with a request body.
- Set the `Content-Type` header value based on the available content types specified in the request body.
- Include the `Content-Type` header in the response type if it is present in the request body.

# Support for Content type in payload data

This PR makes it possible to match the content type of the payload based on the Swagger definition, stilla WIP since the operation can have multiple content types, so should be decided on which ones take precendece

- [ ] I have added or updated unit tests for this change.
- [ ] I have updated the [changelog](https://github.com/rametta/rapini/blob/main/changelog.md) with info about the changes in this PR
