### PR TITLE
Refactor makeRequestsPropertyAssignment to use loop over HTTP methods

### DIFF
--- a/src/common/requests.ts
+++ b/src/common/requests.ts
@@ -9,6 +9,8 @@ import {
 } from "./util";
 
 import type { CLIOptions } from "../cli";
+import { request } from "http";
+import { Interface } from "readline";
 
 export function makeRequests(
   $refs: SwaggerParser.$Refs,
@@ -133,6 +135,8 @@ function makeRequestsDeclaration(
   );
 }
 
+type HttpMethods = 'get' | 'delete' | 'post' | 'put' | 'patch' | 'head' | 'options';
+
 function makeRequestsPropertyAssignment(
   $refs: SwaggerParser.$Refs,
   pattern: string,
@@ -141,19 +145,28 @@ function makeRequestsPropertyAssignment(
 ) {
   const requests: ts.PropertyAssignment[] = [];
   const params = item.parameters;
-  const methods = ["get", "delete", "post", "put", "patch", "head", "options"];
 
-  methods.forEach(method => {
-    if (item[method]) {
+  const methods: HttpMethods[] = [
+    "get",
+    "delete",
+    "post",
+    "put",
+    "patch",
+    "head",
+    "options",
+  ];
+  
+  methods.forEach((method) => {
+    const operation: OpenAPIV3.OperationObject | undefined = item[method];
+    if (operation) {
       requests.push(
-        makeRequest($refs, pattern, method, item[method], options, params)
+        makeRequest($refs, pattern, method, operation, options, params)
       );
     }
   });
 
   return requests;
 }
-
 
 function isRequestBodyObject(
   obj: OpenAPIV3.ReferenceObject | OpenAPIV3.RequestBodyObject

--- a/src/common/requests.ts
+++ b/src/common/requests.ts
@@ -152,8 +152,6 @@ function makeRequestsPropertyAssignment(
 ) {
   const requests: ts.PropertyAssignment[] = [];
   const params = item.parameters;
-  const methods = ["get", "delete", "post", "put", "patch", "head", "options"];
-
   const methods: HttpMethods[] = [
     "get",
     "delete",

--- a/src/common/requests.ts
+++ b/src/common/requests.ts
@@ -141,45 +141,19 @@ function makeRequestsPropertyAssignment(
 ) {
   const requests: ts.PropertyAssignment[] = [];
   const params = item.parameters;
+  const methods = ["get", "delete", "post", "put", "patch", "head", "options"];
 
-  if (item.get) {
-    requests.push(
-      makeRequest($refs, pattern, "get", item.get, options, params)
-    );
-  }
-  if (item.delete) {
-    requests.push(
-      makeRequest($refs, pattern, "delete", item.delete, options, params)
-    );
-  }
-  if (item.post) {
-    requests.push(
-      makeRequest($refs, pattern, "post", item.post, options, params)
-    );
-  }
-  if (item.put) {
-    requests.push(
-      makeRequest($refs, pattern, "put", item.put, options, params)
-    );
-  }
-  if (item.patch) {
-    requests.push(
-      makeRequest($refs, pattern, "patch", item.patch, options, params)
-    );
-  }
-  if (item.head) {
-    requests.push(
-      makeRequest($refs, pattern, "head", item.head, options, params)
-    );
-  }
-  if (item.options) {
-    requests.push(
-      makeRequest($refs, pattern, "options", item.options, options, params)
-    );
-  }
+  methods.forEach(method => {
+    if (item[method]) {
+      requests.push(
+        makeRequest($refs, pattern, method, item[method], options, params)
+      );
+    }
+  });
 
   return requests;
 }
+
 
 function isRequestBodyObject(
   obj: OpenAPIV3.ReferenceObject | OpenAPIV3.RequestBodyObject

--- a/src/common/requests.ts
+++ b/src/common/requests.ts
@@ -9,8 +9,6 @@ import {
 } from "./util";
 
 import type { CLIOptions } from "../cli";
-import { request } from "http";
-import { Interface } from "readline";
 
 export function makeRequests(
   $refs: SwaggerParser.$Refs,

--- a/src/common/requests.ts
+++ b/src/common/requests.ts
@@ -10,6 +10,16 @@ import {
 
 import type { CLIOptions } from "../cli";
 
+const methods = [
+  "get",
+  "delete",
+  "post",
+  "put",
+  "patch",
+  "head",
+  "options",
+] as const;
+
 export function makeRequests(
   $refs: SwaggerParser.$Refs,
   paths: OpenAPIV3.PathsObject,
@@ -133,9 +143,6 @@ function makeRequestsDeclaration(
   );
 }
 
-const methods = ['get', 'delete', 'post', 'put', 'patch', 'head', 'options'] as const;
-type HttpMethods = typeof methods[number];
-
 function makeRequestsPropertyAssignment(
   $refs: SwaggerParser.$Refs,
   pattern: string,
@@ -146,7 +153,7 @@ function makeRequestsPropertyAssignment(
   const params = item.parameters;
 
   methods.forEach((method) => {
-    const operation: OpenAPIV3.OperationObject | undefined = item[method];
+    const operation = item[method];
     if (operation) {
       requests.push(
         makeRequest($refs, pattern, method, operation, options, params)
@@ -156,7 +163,6 @@ function makeRequestsPropertyAssignment(
 
   return requests;
 }
-
 
 function isRequestBodyObject(
   obj: OpenAPIV3.ReferenceObject | OpenAPIV3.RequestBodyObject

--- a/src/common/requests.ts
+++ b/src/common/requests.ts
@@ -133,14 +133,8 @@ function makeRequestsDeclaration(
   );
 }
 
-type HttpMethods =
-  | "get"
-  | "delete"
-  | "post"
-  | "put"
-  | "patch"
-  | "head"
-  | "options";
+const methods = ['get', 'delete', 'post', 'put', 'patch', 'head', 'options'] as const;
+type HttpMethods = typeof methods[number];
 
 function makeRequestsPropertyAssignment(
   $refs: SwaggerParser.$Refs,
@@ -150,15 +144,6 @@ function makeRequestsPropertyAssignment(
 ) {
   const requests: ts.PropertyAssignment[] = [];
   const params = item.parameters;
-  const methods: HttpMethods[] = [
-    "get",
-    "delete",
-    "post",
-    "put",
-    "patch",
-    "head",
-    "options",
-  ];
 
   methods.forEach((method) => {
     const operation: OpenAPIV3.OperationObject | undefined = item[method];
@@ -171,6 +156,7 @@ function makeRequestsPropertyAssignment(
 
   return requests;
 }
+
 
 function isRequestBodyObject(
   obj: OpenAPIV3.ReferenceObject | OpenAPIV3.RequestBodyObject


### PR DESCRIPTION
# Refactor: Simplify makeRequestsPropertyAssignment Function

This PR refactors the `makeRequestsPropertyAssignment` function to use a loop over HTTP methods, reducing repetitive `if` statements and improving code maintainability. The functionality remains unchanged, ensuring backward compatibility. Unit tests have been checked to confirm they pass with the refactor.
