### PR TITLE
Fix not handling header/cookie params

### DIFF
--- a/spec/common/queryKeys.spec.ts
+++ b/spec/common/queryKeys.spec.ts
@@ -76,6 +76,20 @@ describe("makeQueryKeys", () => {
                   type: "string",
                 },
               },
+              {
+                name: 'X-Example',
+                in: 'header',
+                schema: {
+                  type: 'string',
+                },
+              },
+              {
+                name: 'example',
+                in: 'cookie',
+                schema: {
+                  type: 'string',
+                },
+              }
             ],
             responses: {
               default: {

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -364,6 +364,8 @@ export function createParams(
 
   const paramObjects = combineUniqueParams($refs, pathParams, item.parameters);
   return paramObjects
+    // Skip header and cookie parameters
+    .filter(param => param.in === "query" || param.in === "path")
     .sort((x, y) => (x.required === y.required ? 0 : x.required ? -1 : 1)) // put all optional values at the end
     .map((param) => ({
       required: param.required ?? false,


### PR DESCRIPTION
Skips header/cookie params, since they would normally be set globally instead of per-request, although I'm not sure if this is the correct approach, and it just fixes my usecase. Additionally, since the header names were not normalized, it would produce invalid syntax like this: `getPet: (petId?: string, X-Example?: string)`.