### PR TITLE
Fix/48 on success context type

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@ This document outlines the changes from version to version.
 ## Unreleased
 
 ### Fixed
-- #48: Make context parameter required in onSuccess callback to match React Query's types
+- [#48](https://github.com/rametta/rapini/issues/48): Make context parameter required in onSuccess callback to match React Query's types
 
 ## 3.5.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,31 +2,22 @@
 
 This document outlines the changes from version to version.
 
-## Unreleased
+## 2.0.0
 
-### Fixed
-- [#48](https://github.com/rametta/rapini/issues/48): Make context parameter required in onSuccess callback to match React Query's types
+- Added support for SWR
+- Revamped CLI options to accommodate SWR
 
-## 3.5.2
+## 2.1.0
 
-- Fix types generator when yaml file key includes dashes
+- Added support for ESM output (Still includes CJS output)
 
-## 3.4.0
+## 2.3.0
 
-- Update all packages
+- Fix return type for `anyOf` types
 
-## 3.3.0
+## 2.4.0
 
-- Add support for Content-Type header in requests
-
-## 3.2.0
-
-- Fix bug for resolving more inline references to external files
-
-## 3.1.0
-
-- Fix bug for resolving inline reference parameters to external files
-- Fix bug for resolving inline reference types to external files
+- Better handling of thrown errors, outputs clearer CLI errors
 
 ## 3.0.0
 
@@ -40,19 +31,27 @@ A major release with breaking changes. Involves updating type signatures to matc
 - `queryKeys` is exported from the package directly instead of as a return type from `initialize(..)`, this means it can be imported as `import { queryKeys } from 'your-package' `
 - Fixed bug when dealing with vague input for request types and responses, now uses default response type if available, otherwise 2xx response type
 
-## 2.4.0
+## 3.1.0
 
-- Better handling of thrown errors, outputs clearer CLI errors
+- Fix bug for resolving inline reference parameters to external files
+- Fix bug for resolving inline reference types to external files
 
-## 2.3.0
+## 3.2.0
 
-- Fix return type for `anyOf` types
+- Fix bug for resolving more inline references to external files
 
-## 2.1.0
+## 3.3.0
 
-- Added support for ESM output (Still includes CJS output)
+- Add support for Content-Type header in requests
 
-## 2.0.0
+## 3.4.0
 
-- Added support for SWR
-- Revamped CLI options to accommodate SWR
+- Update all packages
+
+## 3.5.2
+
+- Fix types generator when yaml file key includes dashes
+
+### 3.5.3
+
+- Fix for issue #48: Make context parameter required in onSuccess callback to match React Query's types

--- a/changelog.md
+++ b/changelog.md
@@ -2,22 +2,31 @@
 
 This document outlines the changes from version to version.
 
-## 2.0.0
+## Unreleased
 
-- Added support for SWR
-- Revamped CLI options to accommodate SWR
+### Fixed
+- #48: Make context parameter required in onSuccess callback to match React Query's types
 
-## 2.1.0
+## 3.5.2
 
-- Added support for ESM output (Still includes CJS output)
+- Fix types generator when yaml file key includes dashes
 
-## 2.3.0
+## 3.4.0
 
-- Fix return type for `anyOf` types
+- Update all packages
 
-## 2.4.0
+## 3.3.0
 
-- Better handling of thrown errors, outputs clearer CLI errors
+- Add support for Content-Type header in requests
+
+## 3.2.0
+
+- Fix bug for resolving more inline references to external files
+
+## 3.1.0
+
+- Fix bug for resolving inline reference parameters to external files
+- Fix bug for resolving inline reference types to external files
 
 ## 3.0.0
 
@@ -31,23 +40,19 @@ A major release with breaking changes. Involves updating type signatures to matc
 - `queryKeys` is exported from the package directly instead of as a return type from `initialize(..)`, this means it can be imported as `import { queryKeys } from 'your-package' `
 - Fixed bug when dealing with vague input for request types and responses, now uses default response type if available, otherwise 2xx response type
 
-## 3.1.0
+## 2.4.0
 
-- Fix bug for resolving inline reference parameters to external files
-- Fix bug for resolving inline reference types to external files
+- Better handling of thrown errors, outputs clearer CLI errors
 
-## 3.2.0
+## 2.3.0
 
-- Fix bug for resolving more inline references to external files
+- Fix return type for `anyOf` types
 
-## 3.3.0
+## 2.1.0
 
-- Add support for Content-Type header in requests
+- Added support for ESM output (Still includes CJS output)
 
-## 3.4.0
+## 2.0.0
 
-- Update all packages
-
-## 3.5.2
-
-- Fix types generator when yaml file key includes dashes
+- Added support for SWR
+- Revamped CLI options to accommodate SWR

--- a/spec/react-query/rapini-mutation.spec.ts
+++ b/spec/react-query/rapini-mutation.spec.ts
@@ -6,7 +6,7 @@ const expected = `function useRapiniMutation<TData = unknown, TError = unknown, 
     const queryClient = useQueryClient();
     const conf = config?.(queryClient);
     const mutationOptions: typeof options = {
-        onSuccess: (data: TData, variables: TVariables, context?: TContext) => {
+        onSuccess: (data: TData, variables: TVariables, context: TContext) => {
             conf?.onSuccess?.(data, variables, context);
             onSuccess?.(data, variables, context);
         },

--- a/src/react-query/rapini-mutation.ts
+++ b/src/react-query/rapini-mutation.ts
@@ -299,7 +299,7 @@ export function makeRapiniMutation() {
                             undefined,
                             undefined,
                             ts.factory.createIdentifier("context"),
-                            ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+                            undefined,
                             ts.factory.createTypeReferenceNode(
                               ts.factory.createIdentifier("TContext"),
                               undefined


### PR DESCRIPTION
# Fix #48 
As I never seen or worked with code generation before, I took help from ChatGPT Claude 3.5 Sonnnet (Preview) to do this PR. And the suggestions seems legit to me, but... yeah... I think you need to check them 😄 
![BeforeAfter](https://github.com/user-attachments/assets/87aa0eff-dd4d-459d-9ea5-ca37df19bdc4)

![contextNotOptional](https://github.com/user-attachments/assets/7a702f20-0d54-46e1-bfbd-103bbbefa182)

# What?

Makes the context parameter required in onSuccess callback to match React Query's types.
This ensures type safety by properly matching React Query's API where context is:
- Required in onSuccess
- Optional in onError and onSettled

Note that ChatGPT suggested to revert the order of the `changelog.md` file... so I went with that, can undo that if you want.

- [x] I have added or updated unit tests for this change.
- [x] I have updated the [changelog](https://github.com/rametta/rapini/blob/main/changelog.md) with info about the changes in this PR
